### PR TITLE
adds missing arguments when calling render_template()

### DIFF
--- a/section-7/routes.py
+++ b/section-7/routes.py
@@ -49,12 +49,12 @@ def login():
     if form.validate() == False:
       return render_template("login.html", form=form)
     else:
-      email = form.email.data 
-      password = form.password.data 
+      email = form.email.data
+      password = form.password.data
 
       user = User.query.filter_by(email=email).first()
       if user is not None and user.check_password(password):
-        session['email'] = form.email.data 
+        session['email'] = form.email.data
         return redirect(url_for('home'))
       else:
         return redirect(url_for('login'))
@@ -79,10 +79,10 @@ def home():
 
   if request.method == 'POST':
     if form.validate() == False:
-      return render_template('home.html', form=form)
+      return render_template('home.html', form=form, my_coordinates=my_coordinates, places=places)
     else:
       # get the address
-      address = form.address.data 
+      address = form.address.data
 
       # query for places around it
       p = Place()


### PR DESCRIPTION
It seems that on line 82 (section-7/routes.py), the `render_template('home.html', form=form)` was missing `my_coordinates` argument such that when user click search with no input, the app will throw error because of `undefined my_coordinates`.